### PR TITLE
Properly set `response` attribute in the execution context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,13 +30,13 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.2</version>
+        <version>21.0.0</version>
     </parent>
 
     <properties>
-        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
-        <gravitee-bom.version>2.5</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
+        <gravitee-bom.version>3.0.0</gravitee-bom.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.19.6</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-gateway-api.version>1.42.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
 
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>

--- a/src/main/java/io/gravitee/policy/assignattributes/AssignAttributesPolicy.java
+++ b/src/main/java/io/gravitee/policy/assignattributes/AssignAttributesPolicy.java
@@ -43,7 +43,7 @@ public class AssignAttributesPolicy {
     private static final Logger logger = LoggerFactory.getLogger(AssignAttributesPolicy.class);
 
     private static final String REQUEST_VARIABLE = "request";
-    private static final String RESPONSE_VARIABLE = "request";
+    private static final String RESPONSE_VARIABLE = "response";
 
     private final AssignAttributesPolicyConfiguration assignVariablePolicyConfiguration;
 

--- a/src/test/resources/apis/assign-attributes-with-el.json
+++ b/src/test/resources/apis/assign-attributes-with-el.json
@@ -1,0 +1,81 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "POST"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Assign Attributes",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-assign-attributes",
+          "configuration": {
+            "scope": "REQUEST_CONTENT",
+            "attributes": [
+              {
+                "name": "test-request-content",
+                "value": "{#request.content}"
+              }
+            ]
+          }
+        },
+        {
+          "name": "Attributes to headers",
+          "description": "",
+          "enabled": true,
+          "policy": "attributes-to-headers",
+          "scope": "REQUEST_CONTENT",
+          "configuration": {}
+        }
+      ],
+      "post": [
+        {
+          "name": "Assign Attributes",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-assign-attributes",
+          "configuration": {
+            "scope": "RESPONSE_CONTENT",
+            "attributes": [
+              {
+                "name": "test-response-content",
+                "value": "{#response.content}"
+              }
+            ]
+          }
+        },
+        {
+          "name": "Attributes to headers",
+          "description": "",
+          "enabled": true,
+          "policy": "attributes-to-headers",
+          "scope": "RESPONSE_CONTENT",
+          "configuration": {}
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-537
https://github.com/gravitee-io/issues/issues/8810

**Description**

First, bump some Gravitee dependencies because without this bump the tests aren't running anymore due to the dependency on `3.18.0-SNAPSHOT` for the gateway test SDK.
Then, fix the constant used as the `response` attribute, and add an integration test to cover the usage of EL. 
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.5.1-APIM-537-fix-el-on-response-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-assign-attributes/1.5.1-APIM-537-fix-el-on-response-SNAPSHOT/gravitee-policy-assign-attributes-1.5.1-APIM-537-fix-el-on-response-SNAPSHOT.zip)
  <!-- Version placeholder end -->
