### PR TITLE
fix missing BC from previous PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,22 @@
 {
   "extends": [
-    "config:base",
-    "schedule:earlyMondays"
+    "config:base"
   ],
-  "prConcurrentLimit": 3,
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "ci"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "chore"
     }
   ]
 }

--- a/README.adoc
+++ b/README.adoc
@@ -50,6 +50,7 @@ You can use it to retrieve initial request attributes after `Transform headers` 
 | Plugin version | APIM version
 
 | Up to 1.x                   | All
+| From 2.x                   | 4.0+
 |===
 
 == Configuration


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-61

**Description**

Fix missing BC in previous PR and update compatibility matrix in README 
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-APIM-61-message-support-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-assign-attributes/2.0.0-APIM-61-message-support-SNAPSHOT/gravitee-policy-assign-attributes-2.0.0-APIM-61-message-support-SNAPSHOT.zip)
  <!-- Version placeholder end -->
