### PR TITLE
Clean and validate json schema for v4

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,42 +1,39 @@
 {
-  "type": "object",
-  "id": "urn:jsonschema:io:gravitee:policy:assignattributes:configuration:AssignAttributesPolicyConfiguration",
-  "properties": {
-    "scope" : {
-      "title": "Scope",
-      "description": "Execute policy on <strong>request</strong> or <strong>response</strong> phase.",
-      "type" : "string",
-      "default": "REQUEST",
-      "enum" : [ "REQUEST", "RESPONSE", "REQUEST_CONTENT", "RESPONSE_CONTENT" ],
-      "deprecated": true
-    },
-    "attributes" : {
-      "type" : "array",
-      "title": "Assign context attributes",
-      "items" : {
-        "type" : "object",
-        "id" : "urn:jsonschema:io:gravitee:policy:assignattributes:configuration:Attribute",
-        "title": "Attribute",
-        "properties" : {
-          "name" : {
-            "title": "Name",
-            "description": "Name of the attribute",
-            "type" : "string"
-          },
-          "value" : {
-            "title": "Value",
-            "description": "Value of the attribute (Support EL)",
-            "type" : "string",
-            "x-schema-form": {
-              "expression-language": true
-            }
-          }
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "scope": {
+            "title": "Scope",
+            "description": "Select phase to execute the policy.",
+            "type": "string",
+            "default": "REQUEST",
+            "enum": ["REQUEST", "RESPONSE", "REQUEST_CONTENT", "RESPONSE_CONTENT"],
+            "deprecated": true
         },
-        "required": [
-          "name",
-          "value"
-        ]
-      }
+        "attributes": {
+            "type": "array",
+            "title": "Assign context attributes",
+            "items": {
+                "type": "object",
+                "title": "Attribute",
+                "properties": {
+                    "name": {
+                        "title": "Name",
+                        "description": "Name of the attribute.",
+                        "type": "string"
+                    },
+                    "value": {
+                        "title": "Value",
+                        "description": "Value of the attribute (Support EL).",
+                        "type": "string",
+                        "x-schema-form": {
+                            "expression-language": true
+                        }
+                    }
+                },
+                "required": ["name", "value"]
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2085

**Description**

clean and validate json schema for v4

Tested with :
https://gravitee-io-labs.github.io/gravitee-schema-form-checker/
https://particles.gravitee.io/?path=/story/components-form-json-schema--string

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-assign-attributes/2.0.0-json-schema-SNAPSHOT/gravitee-policy-assign-attributes-2.0.0-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
