### PR TITLE
fix: json-schema - add code editor for attribute values

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -27,6 +27,12 @@
                         "title": "Value",
                         "description": "Value of the attribute (Support EL).",
                         "type": "string",
+                        "format": "gio-code-editor",
+                        "gioConfig": {
+                            "monacoEditorConfig": {
+                                "language": "json"
+                            }
+                        },
                         "x-schema-form": {
                             "expression-language": true
                         }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-6746

**Description**

Add code editor for attribute values.


![image](https://github.com/user-attachments/assets/55785216-1382-4836-b8b5-fcaef3b36087)


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.2-APIM-6746-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-assign-attributes/2.0.2-APIM-6746-SNAPSHOT/gravitee-policy-assign-attributes-2.0.2-APIM-6746-SNAPSHOT.zip)
  <!-- Version placeholder end -->
