### PR TITLE
Enable policy for Native Kafka APIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.13.1
+    gravitee: gravitee-io/gravitee@5.1.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/README.adoc
+++ b/README.adoc
@@ -48,9 +48,9 @@ You can use it to retrieve initial request attributes after `Transform headers` 
 
 |===
 | Plugin version | APIM version
-
-| Up to 1.x                   | All
-| From 2.x                   | 4.0+
+| 3.x            | 4.8
+| 2.x            | 4.0 to 4.7
+| Up to 1.x      | All
 |===
 
 == Configuration

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-assign-attributes</artifactId>
-    <version>2.0.3</version>
+    <version>3.0.0-alpha.1</version>
 
     <name>Gravitee.io APIM - Policy - Assign attributes</name>
     <description>Set variables such as request attributes, message attributes and other execution context attributes.</description>
@@ -30,15 +30,14 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.4.1</version>
+        <version>23.2.1</version>
     </parent>
 
     <properties>
-        <gravitee-apim.version>4.6.7</gravitee-apim.version>
+        <gravitee-apim.version>4.8.0-alpha.2</gravitee-apim.version>
 
         <gravitee-sse.version>5.0.0</gravitee-sse.version>
-        <gravitee-http-post.version>2.1.0</gravitee-http-post.version>
-        <gravitee-reactor-message.version>5.0.1</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>7.0.0-alpha.4</gravitee-reactor-message.version>
 
         <maven-plugin-properties.version>1.2.1</maven-plugin-properties.version>
 

--- a/src/main/java/io/gravitee/policy/assignattributes/AssignAttributesPolicy.java
+++ b/src/main/java/io/gravitee/policy/assignattributes/AssignAttributesPolicy.java
@@ -15,10 +15,12 @@
  */
 package io.gravitee.policy.assignattributes;
 
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
-import io.gravitee.gateway.reactive.api.context.MessageExecutionContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseMessageExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpMessageExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.message.Message;
-import io.gravitee.gateway.reactive.api.policy.Policy;
+import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
 import io.gravitee.policy.assignattributes.configuration.AssignAttributesPolicyConfiguration;
 import io.gravitee.policy.v3.assignattributes.AssignAttributesPolicyV3;
 import io.reactivex.rxjava3.core.Completable;
@@ -31,7 +33,7 @@ import lombok.extern.slf4j.Slf4j;
  * @author GraviteeSource Team
  */
 @Slf4j
-public class AssignAttributesPolicy extends AssignAttributesPolicyV3 implements Policy {
+public class AssignAttributesPolicy extends AssignAttributesPolicyV3 implements HttpPolicy {
 
     private final Flowable<Attribute> attributeFlowable;
 
@@ -52,26 +54,26 @@ public class AssignAttributesPolicy extends AssignAttributesPolicyV3 implements 
     }
 
     @Override
-    public Completable onRequest(HttpExecutionContext ctx) {
+    public Completable onRequest(HttpPlainExecutionContext ctx) {
         return assign(ctx);
     }
 
     @Override
-    public Completable onResponse(HttpExecutionContext ctx) {
+    public Completable onResponse(HttpPlainExecutionContext ctx) {
         return assign(ctx);
     }
 
     @Override
-    public Completable onMessageRequest(MessageExecutionContext ctx) {
+    public Completable onMessageRequest(HttpMessageExecutionContext ctx) {
         return ctx.request().onMessage(message -> assign(ctx, message));
     }
 
     @Override
-    public Completable onMessageResponse(MessageExecutionContext ctx) {
+    public Completable onMessageResponse(HttpMessageExecutionContext ctx) {
         return ctx.response().onMessage(message -> assign(ctx, message));
     }
 
-    private Completable assign(HttpExecutionContext executionContext) {
+    private Completable assign(BaseExecutionContext executionContext) {
         if (hasAttributes) {
             return attributeFlowable
                 .flatMapMaybe(attribute ->
@@ -87,7 +89,7 @@ public class AssignAttributesPolicy extends AssignAttributesPolicyV3 implements 
         return Completable.complete();
     }
 
-    private Maybe<Message> assign(MessageExecutionContext executionContext, Message message) {
+    private Maybe<Message> assign(BaseMessageExecutionContext executionContext, Message message) {
         if (hasAttributes) {
             return attributeFlowable
                 .flatMapMaybe(attribute ->

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,5 +6,8 @@ class=io.gravitee.policy.assignattributes.AssignAttributesPolicy
 type=policy
 category=transformation
 icon=assign-attributes.svg
-proxy=REQUEST,RESPONSE
-message=REQUEST,RESPONSE,MESSAGE_REQUEST,MESSAGE_RESPONSE
+
+# HTTP
+http_proxy=REQUEST,RESPONSE
+http_message=PUBLISH,SUBSCRIBE
+

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -11,3 +11,5 @@ icon=assign-attributes.svg
 http_proxy=REQUEST,RESPONSE
 http_message=PUBLISH,SUBSCRIBE
 
+# Native Kafka
+native_kafka=INTERACT,PUBLISH,SUBSCRIBE

--- a/src/test/java/io/gravitee/policy/assignattributes/AssignAttributesPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/assignattributes/AssignAttributesPolicyTest.java
@@ -25,16 +25,13 @@ import static org.mockito.Mockito.verify;
 
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.http.HttpHeaders;
-import io.gravitee.gateway.reactive.api.context.ExecutionContext;
-import io.gravitee.gateway.reactive.api.context.Request;
-import io.gravitee.gateway.reactive.api.context.Response;
+import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpRequest;
+import io.gravitee.gateway.reactive.api.context.http.HttpResponse;
 import io.gravitee.gateway.reactive.api.el.EvaluableRequest;
 import io.gravitee.gateway.reactive.api.el.EvaluableResponse;
 import io.gravitee.gateway.reactive.api.message.DefaultMessage;
 import io.gravitee.gateway.reactive.api.message.Message;
-import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
-import io.gravitee.gateway.reactive.core.context.MutableRequest;
-import io.gravitee.gateway.reactive.core.context.MutableResponse;
 import io.gravitee.gateway.reactive.core.context.interruption.InterruptionFailureException;
 import io.gravitee.policy.assignattributes.configuration.AssignAttributesPolicyConfiguration;
 import io.reactivex.rxjava3.core.Completable;
@@ -62,14 +59,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class AssignAttributesPolicyTest {
 
-    @Mock(extraInterfaces = MutableExecutionContext.class)
-    private ExecutionContext ctx;
+    @Mock
+    private HttpExecutionContext ctx;
 
-    @Mock(extraInterfaces = MutableRequest.class)
-    private Request request;
+    @Mock
+    private HttpRequest request;
 
-    @Mock(extraInterfaces = MutableResponse.class)
-    private Response response;
+    @Mock
+    private HttpResponse response;
 
     @Spy
     private Completable spyCompletable = Completable.complete();

--- a/src/test/java/io/gravitee/policy/assignattributes/AttributesToHeadersPolicy.java
+++ b/src/test/java/io/gravitee/policy/assignattributes/AttributesToHeadersPolicy.java
@@ -23,11 +23,10 @@ import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.stream.BufferedReadWriteStream;
 import io.gravitee.gateway.api.stream.ReadWriteStream;
 import io.gravitee.gateway.api.stream.SimpleReadWriteStream;
-import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
-import io.gravitee.gateway.reactive.api.context.MessageExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpMessageExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.message.Message;
-import io.gravitee.gateway.reactive.api.policy.Policy;
+import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.annotations.OnRequest;
 import io.gravitee.policy.api.annotations.OnRequestContent;
@@ -40,7 +39,7 @@ import io.reactivex.rxjava3.core.Maybe;
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class AttributesToHeadersPolicy implements Policy {
+public class AttributesToHeadersPolicy implements HttpPolicy {
 
     @Override
     public String id() {
@@ -48,26 +47,26 @@ public class AttributesToHeadersPolicy implements Policy {
     }
 
     @Override
-    public Completable onRequest(HttpExecutionContext ctx) {
+    public Completable onRequest(HttpPlainExecutionContext ctx) {
         return Completable.fromRunnable(() -> {
             transform(ctx, "test-request-", ctx.request().headers());
         });
     }
 
     @Override
-    public Completable onResponse(HttpExecutionContext ctx) {
+    public Completable onResponse(HttpPlainExecutionContext ctx) {
         return Completable.fromRunnable(() -> {
             transform(ctx, "test-response-", ctx.response().headers());
         });
     }
 
     @Override
-    public Completable onMessageRequest(MessageExecutionContext ctx) {
+    public Completable onMessageRequest(HttpMessageExecutionContext ctx) {
         return ctx.request().onMessage(message -> transformMessage(message, "test-message-request-"));
     }
 
     @Override
-    public Completable onMessageResponse(MessageExecutionContext ctx) {
+    public Completable onMessageResponse(HttpMessageExecutionContext ctx) {
         return ctx.response().onMessage(message -> transformMessage(message, "test-message-response-"));
     }
 
@@ -136,7 +135,7 @@ public class AttributesToHeadersPolicy implements Policy {
             });
     }
 
-    private void transform(GenericExecutionContext context, String prefix, HttpHeaders headers) {
+    private void transform(HttpPlainExecutionContext context, String prefix, HttpHeaders headers) {
         context
             .getAttributes()
             .forEach((key, value) -> {


### PR DESCRIPTION
**Issue**

N/A

**Description**

BREAKING CHANGE: require APIM 4.8.0+ to work

Enable assign attributes for Native APIs
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-allow-to-use-for-native-kafka-apis-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-assign-attributes/3.0.0-allow-to-use-for-native-kafka-apis-SNAPSHOT/gravitee-policy-assign-attributes-3.0.0-allow-to-use-for-native-kafka-apis-SNAPSHOT.zip)
  <!-- Version placeholder end -->
